### PR TITLE
fix: remove cherry-pick PR in weekly report

### DIFF
--- a/content/2021/2021-07/2021-07-05-pulsar-weekly.md
+++ b/content/2021/2021-07/2021-07-05-pulsar-weekly.md
@@ -40,10 +40,6 @@ This is the Pulsar community weekly update for 2021-06-28 ~ 2021-07-04, with upd
 
   https://github.com/apache/pulsar/pull/11160 ([@urfreespace](https://github.com/urfreespace))
   
-- [Broker] Add an authoritative flag for the topic-level policy to avoid the redirect loop.
-
-  https://github.com/apache/pulsar/pull/11131 ([@codelipenghui](https://github.com/codelipenghui))
-  
 - [Broker] Clear redundant codes.
 
   https://github.com/apache/pulsar/pull/11071 ([@linlinnn](https://github.com/linlinnn))


### PR DESCRIPTION
Signed-off-by: Eric Shen <ericshenyuhao@outlook.com>

### Why for change

Hi, I am the translator for the 2021-07-05-weekly and during the translation there is a cherry-pick PR included in this week as [PR 11131](https://github.com/apache/pulsar/pull/11131). The original PR of 11131 is [PR 11051](https://github.com/apache/pulsar/pull/11051) which was included in [2021-06-28-pulsar-weekly](https://github.com/streamnative/pulsar_weekly/blob/master/content/2021/2021-06/2021-06-28-pulsar-weekly.md)